### PR TITLE
Pass opts to RecursiveIterator; update dependencies; use lodash.merge

### DIFF
--- a/index-es6.js
+++ b/index-es6.js
@@ -1,16 +1,16 @@
 import RecursiveIterator from 'recursive-iterator';
 import delObjectPath from 'del-object-path';
-import objectMerge from 'object-merge';
+import merge from 'lodash.merge';
 
-export default function recursiveOmitBy(object, callback) {
+export default function recursiveOmitBy(object, callback, ...recursiveIteratorOpts) {
   let results;
 
-  for (let meta of new RecursiveIterator(object)) {
+  for (let meta of new RecursiveIterator(object, ...recursiveIteratorOpts)) {
     const shouldOmit = callback(meta);
 
     if (shouldOmit) {
       if (!results) {
-        results = objectMerge({}, object);
+        results = merge({}, object);
       }
 
       delObjectPath(results, meta.path.join('.'));

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "del-object-path": "^0.1.0",
-    "object-merge": "^2.5.1",
-    "recursive-iterator": "^2.0.0"
+    "lodash.merge": "^4.6.2",
+    "recursive-iterator": "^3.3.0"
   }
 }


### PR DESCRIPTION
Whats added:
- You can now pass opts to `RecursiveIterator`
- It enables this library to work with recursive-looking (or recursive) objects
- For this to work I needed to update RecursiveIterator to v3 and use `lodash.merge` instead of `object-merge`.

Its currently published in npm on `@nedomas/recursive-omit-by` if anybody needs it.